### PR TITLE
Update deps

### DIFF
--- a/lib/global.dart
+++ b/lib/global.dart
@@ -3,7 +3,7 @@ import 'package:znn_ledger_dart/znn_ledger_dart.dart';
 
 const znnDaemon = 'znnd';
 const znnCli = 'znn-cli';
-const znnCliVersion = '0.0.6';
+const znnCliVersion = '0.0.7';
 
 final Zenon znnClient = Zenon();
 final KeyStoreManager keyStoreManager =

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -789,11 +789,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "release/v0.0.4"
-      resolved-ref: c66264f599038e15a3457e382cfaaff202ab231a
+      ref: main
+      resolved-ref: "39018c1b5e85285fe5fee7e9f77a988f8d4cebef"
       url: "https://github.com/hypercore-one/znn_ledger_dart.git"
     source: git
-    version: "0.0.4"
+    version: "0.0.5"
   znn_sdk_dart:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   znn_ledger_dart:
     git:
       url: https://github.com/hypercore-one/znn_ledger_dart.git
-      ref: release/v0.0.4
+      ref: main
   bip39: ^1.0.6
   convert: ^3.1.1
   collection: ^1.18.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: znn_cli_dart
 description: Zenon CLI tool
-version: 0.0.6
+version: 0.0.7
 publish_to: none
 
 environment:


### PR DESCRIPTION
This PR updates the dependencies and bumps the version to 0.0.7.

The following dependencies have been updates:
- `znn_ledger_dart` from 0.0.4 to 0.0.5

See https://github.com/hypercore-one/znn_ledger_dart/pull/2 for more information.